### PR TITLE
removed html/body tags in login/register components

### DIFF
--- a/frontend/app/login/layout.jsx
+++ b/frontend/app/login/layout.jsx
@@ -5,14 +5,10 @@ import { useEffect, useState } from 'react';
 
 export default function RootLayout({ children }) {
     return (
-        <html lang="en">
-          <body className="min-h-screen flex flex-col bg-gray-50 text-gray-900">
-              <AuthContextProvider>
-                  <main className="flex-grow container mx-auto px-4 py-8">
-                      {children}
-                  </main>
-              </AuthContextProvider>
-          </body>
-        </html>
+      <AuthContextProvider>
+          <main className="flex-grow container mx-auto px-4 py-8">
+              {children}
+          </main>
+      </AuthContextProvider>
     )
 }

--- a/frontend/app/register/layout.jsx
+++ b/frontend/app/register/layout.jsx
@@ -5,14 +5,10 @@ import { useEffect, useState } from 'react';
 
 export default function RootLayout({ children }) {
     return (
-        <html lang="en">
-          <body className="min-h-screen flex flex-col bg-gray-50 text-gray-900">
-              <AuthContextProvider>
-                  <main className="flex-grow container mx-auto px-4 py-8">
-                      {children}
-                  </main>
-              </AuthContextProvider>
-          </body>
-        </html>
+      <AuthContextProvider>
+          <main className="flex-grow container mx-auto px-4 py-8">
+              {children}
+          </main>
+      </AuthContextProvider>
     )
 }


### PR DESCRIPTION
closes #19 

mismatched html in the login/register components caused a hydration error on the client side